### PR TITLE
Typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ repository locally.
 
 ## OLD:
 - Install the listed FLARE projects as they are dependencies of the FLAREclient (Branches listed are as of December 17 2018. This will updated as branches are merged, and the application is closer to delivery.)
-	- [javaTAXII2](https://github.com/javaTAXII2/tree/develop/) - `develop` branch
+	- [javaTAXII2](https://github.com/cisagov/javaTAXII2/tree/develop/) - `develop` branch
 		- To make sure this is properly installed as a dependency for the client run a `mvn install` or `mvn install -DskipTests` to save some time.
 	- [FLAREutils](https://git.ecicd.dso.ncps.us-cert.gov/fireteam/bcmc/FLAREutils) - `master` branch
 		- To make sure this is properly installed as a dependency for the client run a `mvn install` or `mvn install -DskipTests` to save some time.


### PR DESCRIPTION
This very small change fixes a link in the README that could have led users to pull from non-CISA sources, as demonstrated by @codermakhackerone at https://github.com/javaTAXII2/ (thanks for the report).